### PR TITLE
Improve documentation for patched firmware on MacOs

### DIFF
--- a/docs/patched-firmware/index.md
+++ b/docs/patched-firmware/index.md
@@ -34,7 +34,7 @@ If you'd like to support our work, you can do so on [Ko-Fi](https://ko-fi.com/op
 1. Download the centauri_carbon_developer_mode executable and run it on a computer on the same network as your Centauri Carbon. Follow the on screen instructions to enable developer mode.
     - [Windows build (x64)](https://drive.google.com/file/d/1CROOzsOPZa0S_523WJcTDxCNBs5pvNRz/view?usp=sharing){target="_blank"}
     - [MacOs build (Universal)](https://drive.google.com/file/d/1N6l0DHo1PaB8TD3hzHAWicqE6ILId-LG/view?usp=sharing){target="_blank"}
-        - For the MacOs, Open Terminal, locate the file that you just downloaded, run the following to execute it:
+        - To run this executable, open the Terminal in the same folder as the centauri_carbon_developer_mode file, then run the following commands:
         - `chmod +x centauri_carbon_developer_mode`
         - `./centauri_carbon_developer_mode`
     - [Linux build (x64)](https://drive.google.com/file/d/1hPIMx2H8KXDDGo888rHW8m7f7IMhWHur/view?usp=sharing){target="_blank"}


### PR DESCRIPTION
Even for an experienced MacOs user, this might be a bit confusing to download a document file that has been advertised as an executable.

Therefore added a bit more of context on how to run the file.