### PR TITLE
ci(docs): deploy via gh-pages branch instead of actions/deploy-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,5 @@
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 name: build-docs
+
 on:
   push:
     branches:
@@ -11,25 +7,36 @@ on:
     paths:
       - "docs/**"
       - "zensical.toml"
+      - "requirements.txt"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
-      
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/configure-pages@v6
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - run: pip install -r requirements.txt
+
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:
-          path: site
-      - uses: actions/deploy-pages@v4
-        id: deployment
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          cname: docs.opencentauri.cc


### PR DESCRIPTION
## TL;DR

The zensical migration (#121) switched docs deployment to `actions/deploy-pages`, but repo Pages is still configured as legacy **deploy-from-branch (`gh-pages`/root)** — so the build-docs job was rejected by the `github-pages` environment branch policy before any step ran, and would have failed on the Pages `build_type` mismatch even past that. This PR keeps the zensical build and restores branch-deploy via `peaceiris/actions-gh-pages`. No repo settings changes needed.

## Root cause

Failed run `33826316903` had zero steps/logs — check-run annotations show:

> `Branch "main" is not allowed to deploy to github-pages due to environment protection rules.`

And even with the environment fixed, `actions/deploy-pages` requires Pages `build_type: workflow`; the repo is `legacy` (branch `gh-pages`, root, cname docs.opencentauri.cc) — the old mkdocs flow used `mkdocs gh-deploy` and the settings were never flipped.

## What changed

| File | Change |
|---|---|
| `.github/workflows/docs.yml` | Replace `actions/upload-pages-artifact` + `actions/deploy-pages` (+ `environment`, `pages: write`/`id-token` perms) with `peaceiris/actions-gh-pages` → publishes `site/` to `gh-pages` branch. |

Hardening folded in:
- Action pinned to v4.0.0 commit SHA (`4f9cc66`) — it receives a `contents: write` token
- `concurrency` group serializes `gh-pages` pushes (the deleted `environment:` used to serialize deployments for free)
- Trigger paths extended to `requirements.txt` and the workflow file itself, so this PR's merge self-verifies

## Verification

- `zensical build --clean` on a fresh clone of `main`: "No issues found", 0.57s ✅
- Repo Pages config confirmed via API: `build_type: legacy`, source `gh-pages`/`(root)`, cname `docs.opencentauri.cc` ✅
- Workflow YAML parses clean ✅
- Post-merge: watch the `build-docs` run go green, then `curl -I https://docs.opencentauri.cc/` → 200 (allow ~1 min for Pages publish)

Credit: builds on @Atomique13's zensical migration in #121 (this is fix-forward, not a revert). Approach by @pdscomp.
